### PR TITLE
Hotfix for disease_summary

### DIFF
--- a/disease_summary.md
+++ b/disease_summary.md
@@ -25,32 +25,34 @@ WHERE {
   VALUES ?medgen { medgen:{{medgen_cid}} }
 
   GRAPH <http://togovar.biosciencedbc.jp/medgen> {
-    ?medgen a mo:ConceptID .
-    ?medgen dct:identifier ?medgen_cid .
-    ?medgen rdfs:label ?medgen_label .
+    ?medgen a mo:ConceptID;
+      dct:identifier ?medgen_cid;
+      rdfs:label ?medgen_label .
     OPTIONAL {
       ?medgen skos:definition ?medgen_definition .
     }
 
     OPTIONAL {
-      ?medgen mo:mgconso ?mgconso_mondo .
-      ?mgconso_mondo dct:source mo:MONDO .
-      ?mgconso_mondo rdfs:seeAlso ?mondo .
+      ?medgen mo:mgconso ?mgconso_mondo ;
+        dct:source mo:MONDO ;
+        rdfs:seeAlso ?mondo .
 
       OPTIONAL {
         GRAPH <http://togovar.biosciencedbc.jp/mondo> {
-          ?mondo oboinowl:hasDbXref ?dbxref .
-          FILTER STRSTARTS(STR(?dbxref), "EFO:")
-          BIND(IF(STRLEN(?dbxref) > 0, URI(CONCAT("http://www.ebi.ac.uk/efo/EFO_", SUBSTR(?dbxref,5))), URI("")) AS ?efo)
+          ?mondo oboinowl:hasDbXref ?dbxref_efo .
+          FILTER STRSTARTS(STR(?dbxref_efo), "EFO:")
+          BIND(IF(STRLEN(?dbxref_efo) > 0, URI(CONCAT("http://www.ebi.ac.uk/efo/EFO_", SUBSTR(?dbxref_efo,5))), URI("")) AS ?efo)
         }
       }
-    }
 
-    OPTIONAL {
-      ?medgen mo:mgconso ?mgconso_mesh .
-      ?mgconso_mesh dct:source mo:MSH .
-      ?mgconso_mesh rdfs:seeAlso ?mesh .
-    }
+      OPTIONAL {
+        GRAPH <http://togovar.biosciencedbc.jp/mondo> {
+          ?mondo oboinowl:hasDbXref ?dbxref_mesh.
+          FILTER STRSTARTS(STR(?dbxref_mesh), "MESH")
+          BIND(IF(STRLEN(?dbxref_mesh) > 0, URI(CONCAT("http://id.nlm.nih.gov/mesh/", SUBSTR(?dbxref_mesh,6))), URI("")) AS ?mesh)
+        }
+      }
+   }
   }
 }
 ```
@@ -60,6 +62,10 @@ WHERE {
 ```javascript
 ({medgen}) => {
   const d = medgen.results.bindings[0];
+  if(d == null){
+    return [];
+  }
+
   const medgen_definition = d.medgen_definition ? d.medgen_definition.value : ""
   const efo_link = d.efo ? `EFO:&ensp;<a href="${d.efo.value}">${d.efo.value.replace("http://www.ebi.ac.uk/efo/", "")}</a>` : "EFO:&ensp;No Data";
   const medgen_link = d.medgen_cid ? `MedGen:&ensp;<a href="https://www.ncbi.nlm.nih.gov/medgen/${d.medgen_cid.value}">${d.medgen_cid.value}</a>` : ""

--- a/disease_summary.md
+++ b/disease_summary.md
@@ -33,8 +33,8 @@ WHERE {
     }
 
     OPTIONAL {
-      ?medgen mo:mgconso ?mgconso_mondo ;
-        dct:source mo:MONDO ;
+      ?medgen mo:mgconso ?mgconso_mondo.
+      ?mgconso_mondo dct:source mo:MONDO ;
         rdfs:seeAlso ?mondo .
 
       OPTIONAL {
@@ -48,11 +48,11 @@ WHERE {
       OPTIONAL {
         GRAPH <http://togovar.biosciencedbc.jp/mondo> {
           ?mondo oboinowl:hasDbXref ?dbxref_mesh.
-          FILTER STRSTARTS(STR(?dbxref_mesh), "MESH")
+          FILTER STRSTARTS(STR(?dbxref_mesh), "MESH:")
           BIND(IF(STRLEN(?dbxref_mesh) > 0, URI(CONCAT("http://id.nlm.nih.gov/mesh/", SUBSTR(?dbxref_mesh,6))), URI("")) AS ?mesh)
         }
       }
-   }
+    }
   }
 }
 ```


### PR DESCRIPTION
Fixed disease_summary.md to properly display the metastanza when some of the links to Mondo, EFO, or MeSH are missing. See also https://github.com/togovar/meeting/issues/128#issuecomment-1556389174 .