### PR TITLE
change colil URL from http to https

### DIFF
--- a/gene_publication.md
+++ b/gene_publication.md
@@ -192,7 +192,7 @@ WHERE {
 
 ## Endpoint
 
-http://colil.dbcls.jp/sparql
+https://colil.dbcls.jp/sparql
 
 ## `pmid2citation` PubMed IDs to citation count
 

--- a/variant_publication.md
+++ b/variant_publication.md
@@ -142,7 +142,7 @@ WHERE {
 
 ## Endpoint
 
-http://colil.dbcls.jp/sparql
+https://colil.dbcls.jp/sparql
 
 ## `pmid2citation` PubMed IDs to citation count
 


### PR DESCRIPTION
sparqlistで呼び出しているColilのエンドポイントのURLがhttpからhttpsに変わったためにgene pageとvariant pageの文献スタンザが表示できなくなりました。httpsに変更したcommitのマージをお願いします。