### PR TITLE
FIX: add optional to date_last_evaluated for tgv83266457 in variant_clinvar

### DIFF
--- a/disease_clinvar.md
+++ b/disease_clinvar.md
@@ -33,9 +33,12 @@ WHERE {
       rdfs:label ?condition .
 
     ?_rcv cvo:rcv_classifications/cvo:germline_classification/cvo:description/cvo:description ?interpretation ;
-      cvo:rcv_classifications/cvo:germline_classification/cvo:description/cvo:date_last_evaluated ?last_evaluated ;
       ^cvo:rcv_accession/^cvo:rcv_list/^cvo:classified_record ?clinvar .
-      
+
+    OPTIONAL {
+      ?_rcv cvo:rcv_classifications/cvo:germline_classification/cvo:description/cvo:date_last_evaluated ?last_evaluated .
+    }
+
     ?clinvar a cvo:VariationArchiveType ;
       rdfs:label ?title ;
       cvo:accession ?vcv ;
@@ -133,7 +136,7 @@ ORDER BY ?title ?review_status ?interpretation DESC(?last_evaluated) ?condition
       title: x.title.value,
       interpretation: `<span class="clinical-significance-full" data-sign="${clinical_significance_key(x.interpretation.value)}">${x.interpretation.value}</span>`,
       review_status: `<span class="star-rating"><span data-stars="${review_status_stars(x.review_status.value)}" class="star-rating-item"></span></span><br><span class="status-description">${x.review_status.value}</span>`,
-      last_evaluated: x.last_evaluated.value,
+      last_evaluated: x.last_evaluated?.value
     };
   });
 }

--- a/gene_clinvar.md
+++ b/gene_clinvar.md
@@ -78,8 +78,11 @@ WHERE {
 
     ?_rcv cvo:rcv_classifications/cvo:germline_classification/cvo:description/cvo:description ?interpretation ;
       dct:identifier ?rcv ;
-      cvo:rcv_classifications/cvo:germline_classification/cvo:description/cvo:date_last_evaluated ?last_evaluated ;
       cvo:classified_condition_list/cvo:classified_condition ?_classified_condition .
+
+    OPTIONAL {
+      ?_rcv cvo:rcv_classifications/cvo:germline_classification/cvo:description/cvo:date_last_evaluated ?last_evaluated .
+    }
 
     ?_classified_condition rdfs:label ?condition ;
       dct:source ?db ;

--- a/variant_clinvar.md
+++ b/variant_clinvar.md
@@ -40,8 +40,11 @@ WHERE {
       cvo:classified_record/cvo:rcv_list/cvo:rcv_accession ?_rcv .
 
     ?_rcv cvo:rcv_classifications/cvo:germline_classification/cvo:description/cvo:description ?interpretation ;
-      cvo:rcv_classifications/cvo:germline_classification/cvo:description/cvo:date_last_evaluated ?last_evaluated ;
       cvo:classified_condition_list/cvo:classified_condition ?_classified_condition .
+
+    OPTIONAL {
+      ?_rcv cvo:rcv_classifications/cvo:germline_classification/cvo:description/cvo:date_last_evaluated ?last_evaluated .
+    }
 
     ?_classified_condition rdfs:label ?condition ;
       dct:source ?db ;


### PR DESCRIPTION
ClinVar | VCV003066071 was not found in the variant_clinvar stanza for tgv83266457
See https://grch38.togovar.org/variant/tgv83266457#clinical-significance-clinvar .

The date_last_evaluated of VCV003066071 is null.
See https://www.ncbi.nlm.nih.gov/clinvar/variation/3066071/?redir=vcv .

VCV003066071 should be included in tgv83266457.
See https://grch38.togovar.org/?mode=simple&term=tgv83266457 .