### PR TITLE
remove SPARQLIST_TOGOVAR_APP from gene_protein_browser

### DIFF
--- a/gene_protein_browser.md
+++ b/gene_protein_browser.md
@@ -422,7 +422,7 @@ async ({SPARQLIST_TOGOVAR_APP, hgnc_id, id, uniprot_ptm, uniprot_substitution, p
           alt: a3to1[alt],
           hgvs_p: hgvs_p,
           symbol: a3to1[alt],
-          link: SPARQLIST_TOGOVAR_APP + "/variant/" + v.id,
+          link: "/variant/" + v.id,
           html: html,
           type: "sig_" + min_sig,
           sig_level: cln_sig[min_sig]


### PR DESCRIPTION
developで問題なければ、staging, masterにも適用してください。よろしくお願いします。